### PR TITLE
use existing $(PublishDir) property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,7 +53,7 @@
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="NuGet.Versioning" Version="6.4.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.4.0" />
 
 
     <PackageVersion Include="FluentAssertions" Version="6.8.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,10 +127,9 @@ stages:
             modifyOutputPath: false
         - powershell: eng\commonlight\build.ps1
             -configuration $(_BuildConfig)
-            -prepareMachine
-            -ci
             -restore
             -test
+            -verbosity diag
             -projects $(Build.SourcesDirectory)\**\*Tests.csproj
             /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\test-windows.binlog
             /p:RestoreUsingNuGetTargets=false
@@ -142,6 +141,10 @@ stages:
           inputs:
             testRunner: VSTest
             testResultsFiles: '**/*.trx'
+
+        - publish: '$(Build.SourcesDirectory)/artifacts/bin'
+          displayName: 'Publish Test Artifacts (publish folder)'
+          artifact: Artifacts_Test_$(Agent.Os)_$(_BuildConfig)
 
         - template: ../steps/CoverageResults.yml
           parameters:

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
     "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
-    "DotNet.ArcadeLight.Sdk": "1.0.1-beta"
+    "DotNet.ArcadeLight.Sdk": "1.0.3-beta.g23d8685381"
   }
 }

--- a/src/Common/DotNet.ArcadeLight.Common.Tests/DotNet.ArcadeLight.Common.Tests.csproj
+++ b/src/Common/DotNet.ArcadeLight.Common.Tests/DotNet.ArcadeLight.Common.Tests.csproj
@@ -29,10 +29,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="coverlet.msbuild">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.ArcadeLight.Sdk.Tests/DotNet.ArcadeLight.Sdk.Tests.csproj
+++ b/src/DotNet.ArcadeLight.Sdk.Tests/DotNet.ArcadeLight.Sdk.Tests.csproj
@@ -39,10 +39,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNet.ArcadeLight.Sdk/tools/Tests.targets
+++ b/src/DotNet.ArcadeLight.Sdk/tools/Tests.targets
@@ -62,6 +62,7 @@
         <ResultsCoverletCoveragePath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).coverage.cobertura.xml</ResultsCoverletCoveragePath>
         <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).html</ResultsHtmlPath>
         <ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>
+        <ResultDiagLogfilePath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).diag.log</ResultDiagLogfilePath>
         <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments)</TestRunnerAdditionalArguments>
       </TestToRun>
     </ItemGroup>

--- a/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
+++ b/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
@@ -16,41 +16,41 @@
       <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <_TestRunnerTargetFramework>net6.0</_TestRunnerTargetFramework>
-      <_TestRunnerTargetFramework Condition="'$(TargetFrameworkForNETSDK)' != ''">$(TargetFrameworkForNETSDK)</_TestRunnerTargetFramework>
+      <_TestRunnerTargetFramework Condition="'$(TargetFrameworkForNETSDK)' != ''">%(TestToRun.TargetFramework)</_TestRunnerTargetFramework>
       <_TestRunnerTargetFramework Condition="%(TestToRun.TargetFramework) == 'netcoreapp1.1' or %(TestToRun.TargetFramework) == 'netcoreapp1.0'">netcoreapp1.0</_TestRunnerTargetFramework>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
       <_TargetFileNameNoExt>$([System.IO.Path]::GetFileNameWithoutExtension('$(_TestAssembly)'))</_TargetFileNameNoExt>
       <_TargetDir>$([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))\</_TargetDir>
-      <!-- coverlet collector will create coverage data after publish of test project was done -->
-      <_TargetDir Condition="Exists('$(_TargetDir)publish\)')">$(_TargetDir)publish\</_TargetDir>
-      <_TestAssembly Condition="Exists('$(_TargetDir)publish\)')">$($_TargetDir)$([System.IO.Path]::GetFileName('$(_TestAssembly)'))</_TestAssembly>
-      <_CoreRuntimeConfigPath>$(_TargetDir)$(_TargetFileNameNoExt).runtimeconfig.json</_CoreRuntimeConfigPath>
-      <_CoreDepsPath>$(_TargetDir)$(_TargetFileNameNoExt).deps.json</_CoreDepsPath>
 
       <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe</_TestRunner>
       <_TestRunner Condition="'$(_TestRunner)'==''">$(DotNetTool)</_TestRunner>
 
-      <!--<_TestRunnerArgs>exec depsfile "$(_CoreDepsPath)" runtimeconfig "$(_CoreRuntimeConfigPath)" $(TestRuntimeAdditionalArguments) "$(NuGetPackageRoot)xunit.runner.console/$(XUnitVersion)/tools/$(_TestRunnerTargetFramework)/xunit.console.dll" "$(_TestAssembly)" -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(_TestRunnerAdditionalArguments)</_TestRunnerArgs>-->
-      <!-- coverlet known issue "no-build" symptom (see https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/KnownIssues.md) -->
-      <!-- ToDo: check other solution and avoid unnecessary build -->
-      <!--<_TestRunnerArgs>test "$(MSBuildProjectFullPath)" /p:CollectCoverage=true /p:UseSourceLink=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="%(TestToRun.ResultsCoverletCoveragePath)" - -no-restore - -framework %(TestToRun.TargetFramework) - -logger:"trx;LogFileName=%(TestToRun.ResultsTrxPath)" - -logger:"html;LogFileName=%(TestToRun.ResultsHtmlPath)" - -logger:"console;LogFileName=%(TestToRun.ResultsStdOutPath)"</_TestRunnerArgs>-->
       <_TestResultDirectory>$([System.IO.Path]::GetDirectoryName('%(TestToRun.ResultsTrxPath)'))</_TestResultDirectory>
       <_TestResultTrxFileName>$([System.IO.Path]::GetFileName('%(TestToRun.ResultsTrxPath)'))</_TestResultTrxFileName>
-      <_TestRunnerArgs>vstest "$(_TestAssembly)" /collect:"XPlat Code Coverage" --ResultsDirectory:"$(_TestResultDirectory)" --logger:"trx;LogFileName=$(_TestResultTrxFileName)" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura</_TestRunnerArgs>
+
+      <PublishDir Condition="'$(PublishDir)' == ''">$(_TargetDir)publish</PublishDir>
+      <_PublishExists>false</_PublishExists>
+      <_PublishExists Condition="Exists('$(PublishDir)')">true</_PublishExists>
     </PropertyGroup>
 
-    <Message Text="Publish folder for test exists (coverlet.collector): '$(_TargetDir)publish'" Condition="Exists('$(_TargetDir)publish')" Importance="high" />
-    <Message Text="Publish folder for test not found (coverlet.collector): '$(_TargetDir)publish'" Condition="!Exists('$(_TargetDir)publish')" Importance="high" />
+    <Message Text="Publish folder for test exists (coverlet.collector): $(PublishDir)" Condition="'$(_PublishExists)' == 'true'" Importance="high" />
+    <Message Text="Publish folder for test not found (coverlet.collector): $(PublishDir)" Condition="'$(_PublishExists)' == 'false'" Importance="high" />
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core' and Exists('$(_TargetDir)publish')">
       <!-- coverlet collector will create coverage data after publish of test project was done -->
-      <_TargetDir>$(_TargetDir)publish\</_TargetDir>
+      <_TargetDir>$([MSBuild]::EnsureTrailingSlash('$(PublishDir)'))</_TargetDir>
       <_TestAssembly>$(_TargetDir)$([System.IO.Path]::GetFileName('$(_TestAssembly)'))</_TestAssembly>
     </PropertyGroup>
 
-    <Message Text="Use _TestAssembly  '$(_TestAssembly)'" Condition="Exists('$(_TargetDir)publish)')" Importance="high" />
+    <Message Text="Use _TestAssembly  '$(_TestAssembly)'" Condition="Exists('$(PublishDir)')" Importance="high" />
+
+    <PropertyGroup>
+      <_CoreRuntimeConfigPath>$(_TargetDir)$(_TargetFileNameNoExt).runtimeconfig.json</_CoreRuntimeConfigPath>
+      <_CoreDepsPath>$(_TargetDir)$(_TargetFileNameNoExt).deps.json</_CoreDepsPath>
+      <_TestRunnerArgs>vstest "$(_TestAssembly)" /collect:"XPlat Code Coverage" --ResultsDirectory:"$(_TestResultDirectory)" --logger:"trx;LogFileName=$(_TestResultTrxFileName)" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura</_TestRunnerArgs>    
+    </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' != 'Core'">
       <_XUnitConsoleExe>xunit.console.exe</_XUnitConsoleExe>
@@ -76,11 +76,11 @@
     </PropertyGroup>
 
     <!-- Copy Coverlet-collector dlls with datacollector "XPlat Code Coverage" (local builds only)-->
-    <ItemGroup>
+    <!--<ItemGroup>
       <CoverletDataCollectorFiles Include="$(NuGetPackageRoot)coverlet.collector/$(CoverletCollectorVersion)/build/netstandard1.0/coverlet.collector.dll" />
       <CoverletDataCollectorFiles Include="$(NuGetPackageRoot)coverlet.collector/$(CoverletCollectorVersion)/build/netstandard1.0/coverlet.core.dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(CoverletDataCollectorFiles)" DestinationFolder="$(_TargetDir)" />
+    <Copy SourceFiles="@(CoverletDataCollectorFiles)" DestinationFolder="$(_TargetDir)" />-->
 
     <ItemGroup>
       <_OutputFiles Include="%(TestToRun.ResultsTrxPath)" />

--- a/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
+++ b/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
@@ -7,7 +7,7 @@
   <Target Name="RunTests"
           Outputs="%(TestToRun.ResultsStdOutPath)"
           Condition="'@(TestToRun)' != ''">
-    <!--<Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Test" />-->
+
     <PropertyGroup>
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
@@ -16,13 +16,13 @@
       <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <_TestRunnerTargetFramework>net6.0</_TestRunnerTargetFramework>
-      <_TestRunnerTargetFramework Condition="'$(TargetFrameworkForNETSDK)' != ''">%(TestToRun.TargetFramework)</_TestRunnerTargetFramework>
+      <_TestRunnerTargetFramework Condition="'$(TargetFrameworkForNETSDK)' != ''">$(TargetFrameworkForNETSDK)</_TestRunnerTargetFramework>
       <_TestRunnerTargetFramework Condition="%(TestToRun.TargetFramework) == 'netcoreapp1.1' or %(TestToRun.TargetFramework) == 'netcoreapp1.0'">netcoreapp1.0</_TestRunnerTargetFramework>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
       <_TargetFileNameNoExt>$([System.IO.Path]::GetFileNameWithoutExtension('$(_TestAssembly)'))</_TargetFileNameNoExt>
-      <_TargetDir>$([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))\</_TargetDir>
+      <_TargetDir>$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))))</_TargetDir>
 
       <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe</_TestRunner>
       <_TestRunner Condition="'$(_TestRunner)'==''">$(DotNetTool)</_TestRunner>
@@ -49,7 +49,7 @@
     <PropertyGroup>
       <_CoreRuntimeConfigPath>$(_TargetDir)$(_TargetFileNameNoExt).runtimeconfig.json</_CoreRuntimeConfigPath>
       <_CoreDepsPath>$(_TargetDir)$(_TargetFileNameNoExt).deps.json</_CoreDepsPath>
-      <_TestRunnerArgs>vstest "$(_TestAssembly)" /collect:"XPlat Code Coverage" --ResultsDirectory:"$(_TestResultDirectory)" --logger:"trx;LogFileName=$(_TestResultTrxFileName)" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura</_TestRunnerArgs>    
+      <_TestRunnerArgs>vstest "$(_TestAssembly)" /collect:"XPlat Code Coverage" --ResultsDirectory:"$(_TestResultDirectory)" --logger:"trx;LogFileName=$(_TestResultTrxFileName)" --Diag:"%(TestToRun.ResultDiagLogfilePath);tracelevel=verbose" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile="**/*.Version.cs"</_TestRunnerArgs>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' != 'Core'">
@@ -75,19 +75,9 @@
       <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
     </PropertyGroup>
 
-    <!-- Copy Coverlet-collector dlls with datacollector "XPlat Code Coverage" (local builds only)-->
-    <!--<ItemGroup>
-      <CoverletDataCollectorFiles Include="$(NuGetPackageRoot)coverlet.collector/$(CoverletCollectorVersion)/build/netstandard1.0/coverlet.collector.dll" />
-      <CoverletDataCollectorFiles Include="$(NuGetPackageRoot)coverlet.collector/$(CoverletCollectorVersion)/build/netstandard1.0/coverlet.core.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(CoverletDataCollectorFiles)" DestinationFolder="$(_TargetDir)" />-->
-
     <ItemGroup>
       <_OutputFiles Include="%(TestToRun.ResultsTrxPath)" />
-      <!--<_OutputFiles Include="%(TestToRun.ResultsCoverletCoveragePath)" />
-      <_OutputFiles Include="%(TestToRun.ResultsXmlPath)" />
-      <_OutputFiles Include="%(TestToRun.ResultsHtmlPath)" />
-      <_OutputFiles Include="%(TestToRun.ResultsStdOutPath)" />-->
+      <_OutputFiles Include="%(TestToRun.ResultDiagLogfilePath)" />
     </ItemGroup>
 
     <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>


### PR DESCRIPTION
generates code coverage data locally 

```
build
dotnet publish src\Common\DotNet.ArcadeLight.Common.Tests\DotNet.ArcadeLight.Common.Tests.csproj -f net6.0
dotnet publish src\Common\DotNet.ArcadeLight.Common.Tests\DotNet.ArcadeLight.Common.Tests.csproj -f net7.0
dotnet publish src\DotNet.ArcadeLight.Sdk.Tests\DotNet.ArcadeLight.Sdk.Tests.csproj -f net6.0
dotnet publish src\DotNet.ArcadeLight.Sdk.Tests\DotNet.ArcadeLight.Sdk.Tests.csproj -f net7.0

test -bl
dir /s coverage.cobertura.xml

```