### PR TITLE
remove condition and properties for mono

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
     "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
-    "DotNet.ArcadeLight.Sdk": "1.0.7-beta"
+    "DotNet.ArcadeLight.Sdk": "1.0.8-beta.g8eb8851d30"
   }
 }

--- a/src/DotNet.ArcadeLight.Sdk/tools/RepoLayout.props
+++ b/src/DotNet.ArcadeLight.Sdk/tools/RepoLayout.props
@@ -35,10 +35,6 @@
     <DotNetTool Condition="'$(OS)' == 'Windows_NT'">$(DotNetRoot)dotnet.exe</DotNetTool>
     <DotNetTool Condition="'$(OS)' != 'Windows_NT'">$(DotNetRoot)dotnet</DotNetTool>
   </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(MonoTool)' == ''">
-    <MonoTool>mono</MonoTool>
-  </PropertyGroup>
 
   <PropertyGroup>
     <RepositoryEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'eng'))</RepositoryEngineeringDir>

--- a/src/DotNet.ArcadeLight.Sdk/tools/Tests.targets
+++ b/src/DotNet.ArcadeLight.Sdk/tools/Tests.targets
@@ -8,9 +8,8 @@
     <_GetTestsToRunTarget Condition="'$(TargetFrameworks)' == ''">_InnerGetTestsToRun</_GetTestsToRunTarget>
     <_GetTestsToRunTarget Condition="'$(TargetFrameworks)' != ''">_OuterGetTestsToRun</_GetTestsToRunTarget>
 
-    <!-- The runtime to run tests on: 'Core', 'Mono', 'Full' (desktop FX). -->
+    <!-- The runtime to run tests on: 'Core', 'Full' (desktop FX). -->
     <TestRuntime Condition="'$(TestRuntime)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Core</TestRuntime>
-    <TestRuntime Condition="'$(TestRuntime)' == '' and '$(MSBuildRuntimeType)' == 'Mono'">Mono</TestRuntime>
     <TestRuntime Condition="'$(TestRuntime)' == '' and '$(OS)' == 'Windows_NT'">Full</TestRuntime>
 
     <TestRunnerName Condition="'$(TestRunnerName)' == ''">XUnit</TestRunnerName>

--- a/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
+++ b/src/DotNet.ArcadeLight.Sdk/tools/XUnit/XUnit.Runner.targets
@@ -72,10 +72,6 @@
       <_XUnitConsoleExePath>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\$(_TestRunnerTargetFramework)\$(_XUnitConsoleExe)</_XUnitConsoleExePath>
 
       <_TestRunnerArgs>"$(_TestAssembly)" -noshadow -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(_TestRunnerAdditionalArguments)</_TestRunnerArgs>
-      <_TestRunnerArgs Condition="'$(_TestRuntime)' == 'Mono'">$(TestRuntimeAdditionalArguments) "$(_XUnitConsoleExePath)" $(_TestRunnerArgs)</_TestRunnerArgs>
-
-      <_TestRunner Condition="'$(_TestRuntime)' == 'Mono'">$(MonoTool)</_TestRunner>
-      <_TestRunner Condition="'$(_TestRuntime)' != 'Mono'">$(_XUnitConsoleExePath)</_TestRunner>
     </PropertyGroup>
 
 


### PR DESCRIPTION
.NET 6 uses RIDs for linux, android, IOS, macOS  (https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)