### PR TITLE
prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,23 @@ See [keep a changelog](https://keepachangelog.com/en/1.1.0/) for format guidelin
 
 Use dotnet tool **nbgv** for release workflow (see [Preparing a release](https://github.com/dotnet/Nerdbank.GitVersioning/blob/v3.6.133/doc/nbgv-cli.md#preparing-a-release)).
 
+## [1.7.3](https://github.com/Bertk/arcade-light/compare/v1.7.2...v1.7.3) - 2024-05-02
+
+### Maintenance
+
+* Don't include assemblies that MSBuild ships with (#362) 
+* update xunit version (#363) 
+* update tools version (#361) 
+
+### Dependency Updates
+
+* Bump danielpalme/ReportGenerator-GitHub-Action from 5.2.4 to 5.2.5 (#364) @dependabot
+
 ## [1.7.2](https://github.com/Bertk/arcade-light/compare/v1.7.1...v1.7.2) - 2024-04-10
 
 ### Maintenance
 
-* update .NET SDK version (#349) @Bertk
+* update .NET SDK version (#349) 
 
 ### Dependency Updates
 

--- a/src/DotNetDev.ArcadeLight.Sdk/docs/README.md
+++ b/src/DotNetDev.ArcadeLight.Sdk/docs/README.md
@@ -11,10 +11,10 @@ Lightweight package of [dotnet Arcade](https://github.com/dotnet/arcade) without
 ```json
 {
   "tools": {
-    "dotnet": "8.0.101"
+    "dotnet": "8.0.204"
   },
   "msbuild-sdks": {
-    "DotNetDev.ArcadeLight.Sdk": "1.7.0"
+    "DotNetDev.ArcadeLight.Sdk": "1.7.3"
   }
 }
 ```
@@ -22,6 +22,8 @@ Lightweight package of [dotnet Arcade](https://github.com/dotnet/arcade) without
 #### 2) create `nuget.config` file with a source for the *DotNetDev.ArcadeLight.Sdk* nuget package
 
 #### 3) Add lines in Directory.Build.props
+
+_Please note: [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) is optional_
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.7.3-beta",
+  "version": "1.7.3",
   "versionHeightOffset": 0,
   "nuGetPackageVersion": {
     "semVer": 2.0


### PR DESCRIPTION
### Maintenance

* Don't include assemblies that MSBuild ships with (#362) 
* update xunit version (#363) 
* update tools version (#361) 

### Dependency Updates

* Bump danielpalme/ReportGenerator-GitHub-Action from 5.2.4 to 5.2.5 (#364) @dependabot