### PR TITLE
update coverlet and xunit.v3 version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.1" />
     <!-- https://dev.azure.com/tonerdo/coverlet/_artifacts/feed/coverlet-nightly/NuGet/coverlet.collector -->
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="MSTest" Version="3.6.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.2" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <!-- Libs -->
-    <XUnitV3Version>1.0.0</XUnitV3Version>
+    <XUnitV3Version>1.0.1</XUnitV3Version>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.404"
+    "version": "8.0.405"
   },
   "tools": {
-    "dotnet": "8.0.404"
+    "dotnet": "8.0.405"
   },
   "msbuild-sdks": {
     "DotNetDev.ArcadeLight.Sdk": "1.8.0"

--- a/src/DotNetDev.ArcadeLight.Sdk.Tests/CheckRequiredDotNetVersionTests.cs
+++ b/src/DotNetDev.ArcadeLight.Sdk.Tests/CheckRequiredDotNetVersionTests.cs
@@ -28,7 +28,7 @@ namespace DotNetDev.ArcadeLight.Sdk.Tests
     }
 
     [Theory]
-    [InlineData("8.0.404", true)]
+    [InlineData("8.0.405", true)]
     [InlineData("8.0.888", true)]
     public void CheckRequiredDotNetVersionVerify(string minSdkVersionStr, bool expectedResult)
     {


### PR DESCRIPTION
#### PR Classification
Version updates and test adjustments for compatibility with the latest SDK.

#### PR Summary
This pull request updates several package versions and modifies a test to ensure compatibility with the new SDK version. 
- `CheckRequiredDotNetVersionTests.cs`: Updated test to check for SDK version `8.0.405`.
- `global.json`: Upgraded SDK version from `8.0.404` to `8.0.405`.
- `Versions.props`: Changed `XUnitV3Version` from `1.0.0` to `1.0.1`.
- `Directory.Packages.props`: Updated `coverlet.collector` package version from `6.0.3` to `6.0.4`.
