### PR TITLE
Update project files and .NET versioning settings

### DIFF
--- a/Arcade-light.sln
+++ b/Arcade-light.sln
@@ -5,9 +5,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetDev.ArcadeLight.Sdk", "src\DotNetDev.ArcadeLight.Sdk\DotNetDev.ArcadeLight.Sdk.csproj", "{747A5C75-6069-4C45-8049-AEAA1D864105}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{C53DD924-C212-49EA-9BC4-1827421361EF}"
-	ProjectSection(SolutionItems) = preProject
-		DirectoryBuild.props = DirectoryBuild.props
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetDev.ArcadeLight.Sdk.Tests", "src\DotNetDev.ArcadeLight.Sdk.Tests\DotNetDev.ArcadeLight.Sdk.Tests.csproj", "{BA4250FD-9258-4469-A16D-48A0CAF5A2F8}"
 EndProject

--- a/Arcade-light.sln
+++ b/Arcade-light.sln
@@ -5,6 +5,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetDev.ArcadeLight.Sdk", "src\DotNetDev.ArcadeLight.Sdk\DotNetDev.ArcadeLight.Sdk.csproj", "{747A5C75-6069-4C45-8049-AEAA1D864105}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{C53DD924-C212-49EA-9BC4-1827421361EF}"
+	ProjectSection(SolutionItems) = preProject
+		DirectoryBuild.props = DirectoryBuild.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetDev.ArcadeLight.Sdk.Tests", "src\DotNetDev.ArcadeLight.Sdk.Tests\DotNetDev.ArcadeLight.Sdk.Tests.csproj", "{BA4250FD-9258-4469-A16D-48A0CAF5A2F8}"
 EndProject

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Sdk.props" Sdk="DotNetDev.ArcadeLight.Sdk" />
-  <PropertyGroup>
 
-    <!-- TODO: Remove when a new Arcade.Sdk is consumed with the changes in TargetFrameworkDefaults.props. -->
-    <NetCurrent>net8.0</NetCurrent>
-    <NetPrevious>net7.0</NetPrevious>
-    <NetMinimum>net6.0</NetMinimum>
-    <TargetFrameworkForNETSDK>net8.0</TargetFrameworkForNETSDK>
+  <Import Project="src/DotNetDev.ArcadeLight.Sdk/tools/TargetFrameworkDefaults.props" />
+  <PropertyGroup>
 
     <!-- Do not consider items from obj or bin folder within the project folder -->
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**/*</DefaultItemExcludes>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageVersion Include="System.Security.Permissions" Version="8.0.0" />
-    <!--<PackageVersion Include="System.Text.Json" Version="8.0.5" />-->
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.6.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,13 @@
     <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
   </ItemGroup>
+
+  <!-- Version properties used outside of PackageReference items -->
+  <PropertyGroup>
+    <!-- Libs -->
+    <XUnitV3Version>1.1.0</XUnitV3Version>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
@@ -14,6 +21,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="17.12.6" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
@@ -50,12 +58,12 @@
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageVersion Include="System.Security.AccessControl" Version="6.0.1" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageVersion Include="System.Security.Permissions" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <!--<PackageVersion Include="System.Text.Json" Version="8.0.5" />-->
     <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.6.0" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,5 @@
 <Project>
   <PropertyGroup>
     <!-- Libs -->
-    <XUnitV3Version>1.1.0</XUnitV3Version>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.405"
+    "version": "8.0.406"
   },
   "tools": {
-    "dotnet": "8.0.405"
+    "dotnet": "8.0.406"
   },
   "msbuild-sdks": {
     "DotNetDev.ArcadeLight.Sdk": "1.8.0"

--- a/src/DotNetDev.ArcadeLight.Logging/DotNetDev.ArcadeLight.Logging.csproj
+++ b/src/DotNetDev.ArcadeLight.Logging/DotNetDev.ArcadeLight.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);NU1506</NoWarn>
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
@@ -9,12 +9,8 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != '$(NetCurrent)' ">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="17.11.4" PrivateAssets="all"/>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetCurrent)' ">
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNetDev.ArcadeLight.Logging/PipelinesLogger.cs
+++ b/src/DotNetDev.ArcadeLight.Logging/PipelinesLogger.cs
@@ -53,7 +53,10 @@ namespace DotNetDev.ArcadeLight.Logging
         _ignoredTargets.UnionWith(targetsNotLogged.Split(separator, StringSplitOptions.RemoveEmptyEntries));
       }
 
-      ArgumentNullException.ThrowIfNull(eventSource);
+      if (eventSource == null)
+      {
+        throw new ArgumentNullException(nameof(eventSource));
+      }
 
       eventSource.ErrorRaised += OnErrorRaised;
       eventSource.WarningRaised += OnWarningRaised;

--- a/src/DotNetDev.ArcadeLight.Logging/PipelinesLogger.cs
+++ b/src/DotNetDev.ArcadeLight.Logging/PipelinesLogger.cs
@@ -52,11 +52,12 @@ namespace DotNetDev.ArcadeLight.Logging
       {
         _ignoredTargets.UnionWith(targetsNotLogged.Split(separator, StringSplitOptions.RemoveEmptyEntries));
       }
-
+#pragma warning disable CA1510
       if (eventSource == null)
       {
         throw new ArgumentNullException(nameof(eventSource));
       }
+#pragma warning restore CA1510
 
       eventSource.ErrorRaised += OnErrorRaised;
       eventSource.WarningRaised += OnWarningRaised;

--- a/src/DotNetDev.ArcadeLight.Sdk.Tests/CheckRequiredDotNetVersionTests.cs
+++ b/src/DotNetDev.ArcadeLight.Sdk.Tests/CheckRequiredDotNetVersionTests.cs
@@ -28,7 +28,7 @@ namespace DotNetDev.ArcadeLight.Sdk.Tests
     }
 
     [Theory]
-    [InlineData("8.0.405", true)]
+    [InlineData("8.0.406", true)]
     [InlineData("8.0.888", true)]
     public void CheckRequiredDotNetVersionVerify(string minSdkVersionStr, bool expectedResult)
     {

--- a/src/DotNetDev.ArcadeLight.Sdk.Tests/DotNetDev.ArcadeLight.Sdk.Tests.csproj
+++ b/src/DotNetDev.ArcadeLight.Sdk.Tests/DotNetDev.ArcadeLight.Sdk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolCurrent)</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);testassets\**\*</DefaultItemExcludes>
     <EnableSourceLink>false</EnableSourceLink>
     <NoWarn>$(NoWarn);NU1504;NU1506</NoWarn>
@@ -21,13 +21,7 @@
     <ProjectReference Include="..\DotNet.Internal.DependencyInjection.Testing\DotNet.Internal.DependencyInjection.Testing.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != '$(NetCurrent)' ">
-    <PackageReference Include="Microsoft.Build" VersionOverride="17.8.3" />
-    <PackageReference Include="Microsoft.Build.Framework" VersionOverride="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.3.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetCurrent)' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>

--- a/src/DotNetDev.ArcadeLight.Sdk/DotNetDev.ArcadeLight.Sdk.csproj
+++ b/src/DotNetDev.ArcadeLight.Sdk/DotNetDev.ArcadeLight.Sdk.csproj
@@ -23,7 +23,7 @@
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <EnableGeneratedPackageContent>false</EnableGeneratedPackageContent>
     <_GeneratedVersionFilePath>$(IntermediateOutputPath)DefaultVersions.Generated.props</_GeneratedVersionFilePath>
-    <NoWarn>$(NoWarn);3021;NU5105;NU1505;NU1506;NU1507;SYSLIB0013</NoWarn>
+    <NoWarn>$(NoWarn);3021;NU5105;NU1505;NU1506;NU1507;SYSLIB0013;IDE0079</NoWarn>
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>

--- a/src/DotNetDev.ArcadeLight.Sdk/DotNetDev.ArcadeLight.Sdk.csproj
+++ b/src/DotNetDev.ArcadeLight.Sdk/DotNetDev.ArcadeLight.Sdk.csproj
@@ -1,7 +1,7 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
@@ -31,23 +31,15 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != '$(NetCurrent)' ">
-    <PackageReference Include="Microsoft.Build" VersionOverride="17.12.6" PrivateAssets="all" Publish="false" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.11.4" PrivateAssets="all" Publish="false" ExcludeAssets="runtime"  />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetCurrent)' ">
-    <PackageReference Include="Microsoft.Build" PrivateAssets="all" Publish="false" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" Publish="false" ExcludeAssets="runtime" />
-  </ItemGroup>
-
-  
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="NuGet.Versioning" />
-    <PackageReference Include="System.Collections.Immutable">
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.Metadata" Publish="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Reflection.Metadata" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNetDev.ArcadeLight.Sdk/docs/README.md
+++ b/src/DotNetDev.ArcadeLight.Sdk/docs/README.md
@@ -64,9 +64,7 @@ _Please note: [Central Package Management](https://learn.microsoft.com/en-us/nug
 
 #### 6) Copy `eng\commonlight` from Arcade-light into repo
 
-#### 7) Add the Versions.props file to your eng\ folder
-
-#### 8) configure *Nerdbank.GitVersioning*
+#### 7) configure *Nerdbank.GitVersioning*
 
 Copy `version.json` to repository root folder and configure values (see [versionJson.md](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/versionJson.md))
 
@@ -77,7 +75,7 @@ dotnet tool install -g nbgv
 nbgv install
 ```
 
-#### 9) optionally copy the scripts for `restore`, `build` and `test` to repository root folder
+#### 8) optionally copy the scripts for `restore`, `build` and `test` to repository root folder
 
 ### Use ArcadeLight with command shell or Visual Studio
 

--- a/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -105,11 +105,12 @@ namespace DotNetDev.ArcadeLight.Sdk
     private static string GetTargetsFileContent(string packageId, string sourceLinkUrl)
     {
       string hash;
+#pragma warning disable CA1850
       using (var hashAlg = SHA256.Create())
       {
         hash = BitConverter.ToString(hashAlg.ComputeHash(Encoding.UTF8.GetBytes(packageId)), 0, 20).Replace("-", "");
       }
-
+#pragma
       return $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <Target Name=""_AddSourcePackageSourceRoot_{hash}"" BeforeTargets=""InitializeSourceControlInformation"">

--- a/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -104,7 +104,11 @@ namespace DotNetDev.ArcadeLight.Sdk
 
     private static string GetTargetsFileContent(string packageId, string sourceLinkUrl)
     {
-      string hash = BitConverter.ToString(SHA256.HashData(Encoding.UTF8.GetBytes(packageId)), 0, 20).Replace("-", "");
+      string hash;
+      using (var hashAlg = SHA256.Create())
+      {
+        hash = BitConverter.ToString(hashAlg.ComputeHash(Encoding.UTF8.GetBytes(packageId)), 0, 20).Replace("-", "");
+      }
 
       return $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">

--- a/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/DotNetDev.ArcadeLight.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -110,7 +110,7 @@ namespace DotNetDev.ArcadeLight.Sdk
       {
         hash = BitConverter.ToString(hashAlg.ComputeHash(Encoding.UTF8.GetBytes(packageId)), 0, 20).Replace("-", "");
       }
-#pragma
+#pragma warning restore CA1850
       return $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <Target Name=""_AddSourcePackageSourceRoot_{hash}"" BeforeTargets=""InitializeSourceControlInformation"">

--- a/src/DotNetDev.ArcadeLight.Sdk/tools/SdkTasks/Directory.Build.props
+++ b/src/DotNetDev.ArcadeLight.Sdk/tools/SdkTasks/Directory.Build.props
@@ -1,10 +1,15 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project TreatAsLocalProperty="RepoRoot">
+
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))</RepoRoot>
   </PropertyGroup>
 
   <Import Project="../Directory.Build.props" />
-  <Import Project="../RepoLayout.props"/>
-  <Import Project="Versions.props"/>
+  <Import Project="../RepoDefaults.props" />
+  <Import Project="../RepoLayout.props" />
+  <Import Project="../TargetFrameworkDefaults.props" />
+  <Import Project="Versions.props" />
+
 </Project>
+

--- a/src/DotNetDev.ArcadeLight.Sdk/tools/TargetFrameworkDefaults.props
+++ b/src/DotNetDev.ArcadeLight.Sdk/tools/TargetFrameworkDefaults.props
@@ -1,28 +1,43 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
+
   <!-- Repositories using the arcade SDK can stay up to date with their target framework more easily using the properties in this file.
-       - NetCurrent - The TFM of the major release of .NET that the Arcade SDK aligns with.
-       - NetPrevious - The previously released version of .NET (e.g. this would be net7 if NetCurrent is net8)
-       - NetMinimum - Lowest supported version of .NET the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetMinimum is net6
-       - NetFrameworkMinimum - Lowest supported version of .NET Framework the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetFrameworkMinimum is net462
-       - NetCurrent - The version of .NET Framework that tools (msbuild tasks) should target.
-       - NetFrameworkCurrent - The TFM of the latest version of .NET Framework.
 
        Examples:
-
-       <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
-       <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
-       <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetFrameworkMinimum);net472</TargetFrameworks>
+       <TargetFramework>$(NetCurrent)</TargetFramework>
+       <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+       <TargetFrameworks>$(NetCurrent);$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
   -->
+
   <PropertyGroup>
-    <!-- .NET -->
+    <!-- The TFM of the major release of .NET that the Arcade SDK aligns with. -->
     <NetCurrent>net8.0</NetCurrent>
+
+    <!-- The previously released version of .NET.
+         Undefined when NetMinimum and NetPrevious are identical. -->
     <NetPrevious>net7.0</NetPrevious>
+
+    <!-- Lowest supported version of .NET at the time of the release of NetCurrent. -->
     <NetMinimum>net6.0</NetMinimum>
 
-    <!-- .NET Framework -->
-    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
-    <NetFrameworkToolCurrent>net472</NetFrameworkToolCurrent>
+    <!-- The TFM of the latest version of .NET Framework. -->
     <NetFrameworkCurrent>net481</NetFrameworkCurrent>
+
+    <!-- Lowest supported version of .NET Framework the time of the release of NetCurrent. -->
+    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- The current version of .NET that tools (i.e. msbuild) target.
+         MSBuild tasks and tools should use this version to target the latest TFM that is supported by tooling.
+         Identical with NetCurrent when building from source. -->
+    <NetToolCurrent>$(NetCurrent)</NetToolCurrent>
+
+    <!-- Lowest version of .NET at the time of the release of NetCurrent that is supported by tooling.
+         Identical with NetToolCurrent when building from source. -->
+    <NetToolMinimum>$(NetToolCurrent)</NetToolMinimum>
+
+    <!-- The version of .NET Framework that tools (i.e. msbuild tasks) should target. -->
+    <NetFrameworkToolCurrent>net472</NetFrameworkToolCurrent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Updated `Directory.Packages.props` to include `XUnitV3` version and `Microsoft.IO.Redist` package; updated `System.Runtime.CompilerServices.Unsafe` to `6.1.0`.
- Removed `XUnitV3Version` from `Versions.props`.
- Updated `global.json` SDK and tools version to `8.0.406`.
- Changed target frameworks in `DotNetDev.ArcadeLight.Logging.csproj` and `DotNetDev.ArcadeLight.Sdk.Tests.csproj` to use `$(NetToolCurrent)`.

- Updated expected SDK version in `CheckRequiredDotNetVersionTests`.
- Simplified package references in `DotNetDev.ArcadeLight.Sdk.csproj`.
- Improved hash generation in `GenerateSourcePackageSourceLinkTargetsFile.cs`.
- Added `RepoRoot` property in `Directory.Build.props` and adjusted import order.
- Introduced `TargetFrameworkDefaults.props` for managing .NET version properties.